### PR TITLE
Add a `container-build` Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 # Copyright (c) 2018 Platform9 Systems, Inc.
 #
 # Usage:
-# make              # builds the artifact
-# make clean        # removes the artifact and the vendored packages
-# make clean-all    # same as make clean + removes the bin dir which houses dep
+# make                 # builds the artifact
+# make clean           # removes the artifact and the vendored packages
+# make clean-all       # same as make clean + removes the bin dir which houses dep
+# make container-build # build artifact on a Linux based container using the latest golang
 
 SHELL := /usr/bin/env bash
 BUILD_NUMBER ?= 10
@@ -19,13 +20,16 @@ DEP_BIN_GIT := https://github.com/golang/dep/releases/download/v0.4.1/dep-$(DETE
 DEP_BIN := $(CWD)/bin/dep
 BIN := pf9-clusteradm
 
-.PHONY: clean gopath depnolock
+.PHONY: clean gopath depnolock container-build
 
 export GOPATH=$(CWD)
 export DEPNOLOCK=1 # issue with vboxsf (vagrant + vbox) : https://github.com/golang/dep/issues/947
 
 default: $(BIN)
 	tree $(BUILD_DIR) || true
+
+container-build:
+	docker run --rm -v $(PWD):/build -w /build golang:latest make
 
 $(DEP_BIN):
 	mkdir $(CWD)/bin


### PR DESCRIPTION
This new target will build the pf9-clusteradm binary inside a
Linux-based container (Debian 9 at the time of writing) using
the latest golang.

This will mount the current working directory as a volume to the
container, set the volume as the working directory and run `make`.

This target will be used for TeamCity builds.