### PR TITLE
Persist etcd member information, and disallow duplicate machine add

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -362,7 +362,7 @@
     "sshproviderconfig",
     "sshproviderconfig/v1alpha1"
   ]
-  revision = "31e0eebca3c44fcfc382921eceb7616be825272f"
+  revision = "d5a69d12351951e1dfc7449922e771a5cb7d2a4c"
 
 [[projects]]
   name = "github.com/prometheus/client_golang"

--- a/common/util.go
+++ b/common/util.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"net"
 
-	sshProvider "github.com/platform9/ssh-provider/sshproviderconfig/v1alpha1"
 	sshconfigv1 "github.com/platform9/ssh-provider/sshproviderconfig/v1alpha1"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,7 +16,7 @@ func CreateSSHClusterProviderConfig(routerID int, vip string) (*clusterv1.Provid
 			APIVersion: "sshproviderconfig/v1alpha1",
 			Kind:       "SSHClusterProviderConfig",
 		},
-		VIPConfiguration: &sshProvider.VIPConfiguration{
+		VIPConfiguration: &sshconfigv1.VIPConfiguration{
 			IP:       net.ParseIP(vip),
 			RouterID: routerID,
 		},
@@ -64,4 +63,55 @@ func DecodeSSHClusterProviderConfig(pc clusterv1.ProviderConfig) sshconfigv1.SSH
 	}
 	sshProviderConfigCodec.DecodeFromProviderConfig(pc, &config)
 	return config
+}
+
+func DecodeSSHMachineProviderStatus(machineProviderStatus clusterv1.ProviderStatus) sshconfigv1.SSHMachineProviderStatus {
+	config := sshconfigv1.SSHMachineProviderStatus{}
+
+	sshProviderConfigCodec, err := sshconfigv1.NewCodec()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if machineProviderStatus.Value != nil {
+		sshProviderConfigCodec.DecodeFromProviderStatus(machineProviderStatus, &config)
+	}
+	return config
+}
+
+func EncodeSSHMachineProviderStatus(machineProviderStatus sshconfigv1.SSHMachineProviderStatus) (*clusterv1.ProviderStatus, error) {
+	sshProviderConfigCodec, err := sshconfigv1.NewCodec()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return sshProviderConfigCodec.EncodeToProviderStatus(machineProviderStatus.DeepCopyObject())
+}
+
+func EncodeSSHClusterProviderConfig(providerConfig sshconfigv1.SSHClusterProviderConfig) (*clusterv1.ProviderConfig, error) {
+	sshProviderConfigCodec, err := sshconfigv1.NewCodec()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return sshProviderConfigCodec.EncodeToProviderConfig(providerConfig.DeepCopyObject())
+}
+
+func DecodeSSHClusterProviderStatus(clusterProviderStatus clusterv1.ProviderStatus) sshconfigv1.SSHClusterProviderStatus {
+	config := sshconfigv1.SSHClusterProviderStatus{}
+
+	sshProviderConfigCodec, err := sshconfigv1.NewCodec()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if clusterProviderStatus.Value != nil {
+		sshProviderConfigCodec.DecodeFromProviderStatus(clusterProviderStatus, &config)
+	}
+
+	return config
+}
+
+func EncodeSSHClusterProviderStatus(clusterProviderStatus sshconfigv1.SSHClusterProviderStatus) (*clusterv1.ProviderStatus, error) {
+	sshProviderConfigCodec, err := sshconfigv1.NewCodec()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return sshProviderConfigCodec.EncodeToProviderStatus(clusterProviderStatus.DeepCopyObject())
 }

--- a/vendor/github.com/platform9/ssh-provider/machine/nodeadm.go
+++ b/vendor/github.com/platform9/ssh-provider/machine/nodeadm.go
@@ -45,6 +45,8 @@ func (sa *SSHActuator) NewNodeadmConfiguration(pm *provisionedmachine.Provisione
 	cfg.VIPConfiguration.RouterID = cpc.VIPConfiguration.RouterID
 	cfg.VIPConfiguration.NetworkInterface = pm.VIPNetworkInterface
 	cfg.MasterConfiguration = *masterConfiguration.DeepCopy()
+	cfg.MasterConfiguration.API.AdvertiseAddress = cpc.VIPConfiguration.IP.String()
+	cfg.MasterConfiguration.APIServerCertSANs = []string{cpc.VIPConfiguration.IP.String(), pm.SSHConfig.Host}
 	return cfg, nil
 }
 


### PR DESCRIPTION
Add support to decode etcd member information from
cluster status and persisting the state in cluster
state file
Add check if machine is already added to the cluster
state
Added utility methods to encode/decode
Fixes issues #7, #8, #9