### PR TITLE
Fix migrate issues

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -41,7 +41,7 @@ func Migrate() {
 	defer file.Close()
 	stateBytes, err := ioutil.ReadAll(file)
 
-	migratedBytes, err := migrate.MigrateV0toV1(&stateBytes)
+	migratedBytes, err := migrate.MigrateV0toV1(stateBytes)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/migrate/migrate_v1.go
+++ b/pkg/migrate/migrate_v1.go
@@ -26,10 +26,10 @@ type StateV0toV1 struct {
 }
 
 // MigrateV0toV1 adds a schemaVersion field to the state file
-func MigrateV0toV1(stateBytes *[]byte) ([]byte, error) {
+func MigrateV0toV1(stateBytes []byte) ([]byte, error) {
 	tempState := new(StateV0toV1)
-	if err := yaml.Unmarshal(*stateBytes, tempState); err != nil {
-		return []byte("What"), fmt.Errorf("unable to unmarshal state from YAML: %v", err)
+	if err := yaml.Unmarshal(stateBytes, tempState); err != nil {
+		return []byte{}, fmt.Errorf("unable to unmarshal state from YAML: %v", err)
 	}
 
 	switch tempState.SchemaVersion {

--- a/pkg/migrate/migrate_v1_test.go
+++ b/pkg/migrate/migrate_v1_test.go
@@ -2,7 +2,6 @@ package migrate
 
 import (
 	"github.com/ghodss/yaml"
-	"github.com/platform9/cctl/pkg/util/migrate"
 	"log"
 	"strings"
 	"testing"
@@ -17,7 +16,7 @@ func marshal(s StateV0toV1) []byte {
 }
 
 func decode(b []byte) {
-	newState := util.DecodeMigratedState(b)
+	newState := DecodeMigratedState(b)
 	if newState.SchemaVersion != 1 {
 		log.Fatal("Migration failed.")
 	}
@@ -37,7 +36,7 @@ func testSchemaVersionUpdate(t *testing.T) {
 		}
 		stateBytes := marshal(testYaml)
 
-		migratedBytes, err := MigrateV0toV1(&stateBytes)
+		migratedBytes, err := MigrateV0toV1(stateBytes)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -53,7 +52,7 @@ func testHigherSchemaVersion(t *testing.T) {
 		}
 		stateBytes := marshal(testYaml)
 
-		_, err := MigrateV0toV1(&stateBytes)
+		_, err := MigrateV0toV1(stateBytes)
 		if err != nil {
 			if !strings.Contains(err.Error(), "unable to migrate state file to schemaVersion 1: schemaVersion is 5") {
 				log.Fatal("Migration failed")
@@ -69,7 +68,7 @@ func testSameSchemaVersion(t *testing.T) {
 		}
 		stateBytes := marshal(testYaml)
 
-		migratedBytes, err := MigrateV0toV1(&stateBytes)
+		migratedBytes, err := MigrateV0toV1(stateBytes)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/migrate/util.go
+++ b/pkg/migrate/util.go
@@ -14,7 +14,6 @@ func EncodeMigratedState(any interface{}) []byte {
 	return buf
 }
 
-
 func DecodeMigratedState(any []byte) state.State {
 	var thisState state.State
 	err := yaml.Unmarshal(any, &thisState)


### PR DESCRIPTION
+ Remove unnecessary string in the
+ Update parameter type to slice of bytes instead of pointer to slice of
bytes since a slice already holds a reference to the underlying array