### PR TITLE
Add unit test target to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,11 @@ ensure: $(DEP_BIN)
 $(BIN):
 	go build -o $(BIN) -ldflags "$(LDFLAGS)"
 
+unit-test:
+	pushd pkg/migrate && \
+	go test -v && \
+	popd
+
 format:
 	gofmt -w -s *.go
 	gofmt -w -s */*.go


### PR DESCRIPTION
```[16:08]vanadium[cctl](⎇  add-unit-test) make unit-test
pushd pkg/migrate && \
  go test -v && \
	popd
~/go/src/github.com/platform9/cctl/pkg/migrate ~/go/src/github.com/platform9/cctl
=== RUN   TestMigrateV0toV1
=== RUN   TestMigrateV0toV1/Update_schemaVersion_to_1
=== RUN   TestMigrateV0toV1/Cannot_update_schemaVersion_>_1
=== RUN   TestMigrateV0toV1/Update_same_schemaVersion
--- PASS: TestMigrateV0toV1 (0.00s)
    --- PASS: TestMigrateV0toV1/Update_schemaVersion_to_1 (0.00s)
    --- PASS: TestMigrateV0toV1/Cannot_update_schemaVersion_>_1 (0.00s)
    --- PASS: TestMigrateV0toV1/Update_same_schemaVersion (0.00s)
PASS
ok  	github.com/platform9/cctl/pkg/migrate	0.058s
~/go/src/github.com/platform9/cctl```