### PR TITLE
Update APIEndpoint in ClusterStatus when adding master in non-ha cluster

### DIFF
--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -164,7 +164,7 @@ func createMachine(ip string, port int, iface string, roleString string, publicK
 		if ok {
 			apiServerPort, err = strconv.Atoi(apiServerPortStr)
 			if err != nil {
-				log.Fatalf("Unable to read cluster config key: %s", spconstants.KubeAPIServerSecurePortKey)
+				log.Fatalf("Unable to parse cluster config value for kubeAPIServer with key: %s", spconstants.KubeAPIServerSecurePortKey)
 			}
 		}
 


### PR DESCRIPTION
When adding a worker to a non-ha cluster, the master IP used by the worker on `nodeadm join` is empty because the vip is also empty. 

This change will update the APIEndpoint (used by the worker to find the master IP) in the ClusterSpec with the IP of the master when it is created. 



