### PR TITLE
All in one 2 node  demo w/ vagrant , embedded binaries, etc.. that (mostly) works w/o internet connectivity.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 bin
-cctl
+cctl-*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 bin
-cctl-*
+cctl

--- a/Makefile
+++ b/Makefile
@@ -61,4 +61,4 @@ clean:
 	rm -rf $(BIN)
 
 test:
-	go test -v ./...
+	echo "skipping"

--- a/Makefile
+++ b/Makefile
@@ -61,4 +61,4 @@ clean:
 	rm -rf $(BIN)
 
 test:
-	echo "skipping"
+	go test -v ./...

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Along with [etcdadm](https://github.com/kubernetes-sigs/etcdadm) and [nodeadm](h
 ```
 go get -u github.com/platform9/cctl
 ```
+
+Quick demo: cd hack/ and follow the directions for the Vagrant recipe!
+
 ## Usage
 ```
 $GOPATH/bin/cctl [command]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,43 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  $num_instances = 2
+  (1..$num_instances).each do |i|
+    config.vm.define vm_name = "centos-7-%02d.vagrant.test"  % [i] do |config|
+
+    config.vm.box = "centos/7"
+
+    ip = "172.100.100.#{i+2}"
+
+    config.vm.network :private_network, ip: ip
+      config.vm.provider "virtualbox" do |vb|
+        config.vm.synced_folder "./hack/", "/vagrant", type: "rsync", rsync__args: ["--verbose", "--archive", "--delete", "-z"]
+        vb.memory = "1028"
+        vb.cpus = "1"
+      end
+      config.vm.provision "shell" do |s|
+        ssh_pub_key = File.readlines("#{Dir.home}/.ssh/id_rsa.pub").first.strip
+        s.inline = <<-SHELL
+
+          echo #{ssh_pub_key} >> /home/vagrant/.ssh/authorized_keys
+          sudo mkdir -p /opt/bin
+          sudo chmod -R 777 /opt/bin
+          sudo mkdir -p /var/cache/ssh-provider/nodeadm/v0.2.1 
+          sudo mkdir -p /var/cache/ssh-provider/etcdadm/v0.1.1
+
+          sudo chmod -R 777 /var/cache/ssh-provider/
+
+          cp /vagrant/nodeadm-linux /var/cache/ssh-provider/nodeadm/v0.2.1/nodeadm
+          cp /vagrant/etcdadm-linux /var/cache/ssh-provider/etcdadm/v0.1.1/etcdadm
+
+          sudo yum install -y yum-utils device-mapper-persistent-data lvm2 ; sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo ; sudo yum install -y docker-ce ; sudo usermod -aG docker vagrant
+  
+          echo "Starting docker daemon..."
+          sudo systemctl start docker
+
+        SHELL
+      end
+     end
+  end
+end

--- a/hack/REAMDE.md
+++ b/hack/REAMDE.md
@@ -1,0 +1,10 @@
+This file demonstrates what you need to do to install a CCTL cluster.
+
+Depending on the VM type you use, you might need to setup your hypervisor to use 
+eth0 as the private IP, rather then as a NAT destination.
+
+To run this demo, modify the Vagrantfile if needed, and just run the cctl-demo.sh script.
+
+Again: This script is purely for learning and understanding the inner workings of a CCTL
+
+installation.

--- a/hack/cctl-demo.sh
+++ b/hack/cctl-demo.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+function intro() {
+	echo "Welcome to the KlusterKit interactive Demo !!!"
+}
+
+function compilation() {
+	if [[ -f "cctl-osx" ]] ; then
+		echo "Detected cctl binary, no need to compile it..."	
+	else
+		echo "First we'll compile the CCTL tool for OS X... "
+		pushd ../
+			OS=linux make container-build
+			cp cctl* ./hack
+		popd
+	fi
+}
+
+
+function vagrant_up() {
+	echo "Ok, now lets spin up some infrastructure..."
+	pushd ../
+		vagrant up
+	popd
+	
+	echo "Typically, you'll replace this step with a terraform or other cloud provisioning step"
+	echo "Note that we will need to be able to SSH into these VMs for KlusterKit to work!"
+}
+
+function initialize() {
+	VM="172.100.100.3"
+	CCTL="./cctl-osx"
+
+	set -x
+	echo "credential"
+	$CCTL create credential --state cctl-state.yaml --user vagrant --private-key ~/.ssh/id_rsa
+	echo "cluster..."
+	$CCTL create cluster --state cctl-state.yaml --pod-network 192.168.0.0/16 --service-network 192.169.0.0/24
+	echo "machine..."
+	$CCTL create machine --iface eth1 --state cctl-state.yaml --ip 172.100.100.3 --role master
+	$CCTL create machine --iface eth1 --state cctl-state.yaml --ip 172.100.100.2 --role worker
+}
+
+intro
+compilation
+vagrant_up
+initialize
+

--- a/hack/cctl-demo.sh
+++ b/hack/cctl-demo.sh
@@ -10,7 +10,7 @@ function compilation() {
 	else
 		echo "First we'll compile the CCTL tool for OS X... "
 		pushd ../
-			OS=linux make container-build
+			make container-build
 			cp cctl* ./hack
 		popd
 	fi


### PR DESCRIPTION
This will give the community a quick way to burn through a CCTL installation and customize their own recipes.  It Will work as long as eth0 is setup correctly, with zero external dependencies (i.e. i added the linux binaries to the commits, its a little ugly but its an awesome UX and gives people essentially a "cctl from zero" experience , which they can translate to their on prem setup in an intuitive way. 